### PR TITLE
chore: prepare project for publishing.

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,5 @@
 src
+tmp
+coverage
+yarn-error.log
+*.test.js

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "lint": "./node_modules/.bin/eslint src/* --fix",
     "test":
       "nyc mocha -r chai/register-should --require babel-core/register './src/**/*.test.js'",
-    "prepublish": "npm run build",
+    "prepare": "npm run build",
     "precommit-msg": "echo 'Pre-commit checks...' && exit 0"
   },
   "nyc": {


### PR DESCRIPTION
 - Updated npmignore file so that it only packs required files.
 - Replaced the deprecated 'prepublish' with 'prepare'.